### PR TITLE
perf: fix LCP image priority and events/[id] fetch waterfall

### DIFF
--- a/app/(app)/(no-nav)/events/[id]/_components/uncancel-event-button.tsx
+++ b/app/(app)/(no-nav)/events/[id]/_components/uncancel-event-button.tsx
@@ -19,7 +19,12 @@ export function UncancelEventButton({ eventId }: { eventId: string }) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" size="icon" aria-label="Restore event" className="size-9">
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label="Restore event"
+          className="size-9"
+        >
           <RotateCcw className="size-4" />
         </Button>
       </DialogTrigger>

--- a/app/(app)/(no-nav)/events/[id]/page.tsx
+++ b/app/(app)/(no-nav)/events/[id]/page.tsx
@@ -82,23 +82,26 @@ export default async function EventDetailPage({ params }: Props) {
 
   if (!event) notFound();
 
-  const canManage = await canManageChurch(
-    session?.user?.id,
-    session?.user?.role,
-    event.churchId
-  );
-
-  if (event.isDraft && !canManage) notFound();
-  const attendees = canManage ? await getEventAttendees(id) : undefined;
-
   const isAttending = myAttendance !== null;
 
-  const questions = await getEventQuestions(id);
+  const [canManage, questions] = await Promise.all([
+    canManageChurch(session?.user?.id, session?.user?.role, event.churchId),
+    getEventQuestions(id),
+  ]);
 
-  const myResponses =
+  if (event.isDraft && !canManage) notFound();
+
+  const [attendees, myResponses] = await Promise.all([
+    canManage ? getEventAttendees(id) : Promise.resolve(undefined),
     session?.user?.id && questions.length > 0 && isAttending
-      ? await getMyResponses(id, session.user.id)
-      : {};
+      ? getMyResponses(id, session.user.id)
+      : Promise.resolve(
+          {} as Record<
+            string,
+            { answer: string | null; fileUrl: string | null }
+          >
+        ),
+  ]);
 
   const { registration, camp } = parseEventMetadata(event.metadata);
   const myAttendeeMeta = myAttendance

--- a/app/(app)/(with-nav)/page.tsx
+++ b/app/(app)/(with-nav)/page.tsx
@@ -80,9 +80,10 @@ export default async function Home({
                       ({filteredEvents.length})
                     </span>
                   </h2>
-                  {filteredEvents.map((event) => (
+                  {filteredEvents.map((event, index) => (
                     <EventCard
                       key={event.id}
+                      priority={index === 0}
                       event={{
                         ...event,
                         badge: event.tag,

--- a/app/globals.css
+++ b/app/globals.css
@@ -64,7 +64,7 @@
   --muted-foreground: oklch(0.48 0.016 285.938);
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
-  --destructive: oklch(0.50 0.245 27.325);
+  --destructive: oklch(0.5 0.245 27.325);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.75 0.183 55.934);

--- a/components/event-card.tsx
+++ b/components/event-card.tsx
@@ -17,9 +17,10 @@ interface EventCardProps {
     isDraft?: boolean;
     photoUrl?: string | null;
   };
+  priority?: boolean;
 }
 
-export function EventCard({ event }: EventCardProps) {
+export function EventCard({ event, priority = false }: EventCardProps) {
   return (
     <Link href={`/events/${event.id}`}>
       <Card className="shadow-card overflow-hidden rounded-2xl border-0 bg-white py-0">
@@ -32,6 +33,7 @@ export function EventCard({ event }: EventCardProps) {
                 fill
                 className="object-cover"
                 sizes="(max-width: 768px) 100vw, 50vw"
+                priority={priority}
               />
             </div>
           )}

--- a/components/infinite-event-list.tsx
+++ b/components/infinite-event-list.tsx
@@ -77,9 +77,10 @@ export function InfiniteEventList({
   return (
     <section className="flex flex-col gap-3">
       {title && <h2 className="text-base font-semibold">{title}</h2>}
-      {items.map((item) => (
+      {items.map((item, index) => (
         <EventCard
           key={item.id}
+          priority={index === 0}
           event={{
             ...item,
             badge: item.tag,


### PR DESCRIPTION
Add `priority` prop to EventCard and pass it for the first item in InfiniteEventList and home page search results so the above-fold image preloads as the LCP element instead of being lazily fetched.

Parallelise data fetching on /events/[id]: canManageChurch + getEventQuestions now run concurrently, then getEventAttendees + getMyResponses run concurrently, removing two sequential DB round trips from the render path.