### PR TITLE
perf(auth): embed church memberships in JWT to eliminate per-request …

### DIFF
--- a/app/(app)/(no-nav)/events/[id]/edit/page.tsx
+++ b/app/(app)/(no-nav)/events/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { UserRole } from "@prisma/client";
 import { getEventById } from "@/lib/actions/data-events";
-import { getChurchesByManager } from "@/lib/actions/data-churches";
+import { getChurchesByIds } from "@/lib/actions/data-churches";
 import {
   getEventQuestions,
   hasEventResponses,
@@ -27,9 +27,13 @@ export default async function EditEventPage({ params }: Props) {
     redirect("/");
   if (!event) notFound();
 
+  const managedIds = [
+    ...(session.user.organiserChurchIds ?? []),
+    ...(session.user.adminChurchIds ?? []),
+  ];
   const [churches, questions, libraryItems, questionsLocked] =
     await Promise.all([
-      getChurchesByManager(session.user.id),
+      getChurchesByIds(managedIds),
       getEventQuestions(id),
       getQuestionLibraryForUser(session.user.id),
       hasEventResponses(id),

--- a/app/(app)/(no-nav)/events/[id]/page.tsx
+++ b/app/(app)/(no-nav)/events/[id]/page.tsx
@@ -27,7 +27,7 @@ import {
   parseEventMetadata,
   parseEventAttendeeMetadata,
 } from "@/lib/validations/event";
-import { canManageChurch } from "@/lib/permissions";
+import { canManageChurchFromSession } from "@/lib/permissions";
 import { EventDatetime } from "@/components/event-datetime";
 import { formatDateOnly, parseDateOfBirth } from "@/lib/datetime";
 import { InfoField } from "@/components/ui/info-field";
@@ -47,14 +47,9 @@ export async function generateMetadata({ params }: Props) {
   const event = await getEventById(id);
   if (!event) return { title: "Event Not Found" };
   if (event.isDraft) {
-    // Draft: need auth check — infrequent, cost is acceptable
     const session = await auth();
-    const canManage = await canManageChurch(
-      session?.user?.id,
-      session?.user?.role,
-      event.churchId
-    );
-    if (!canManage) return { title: "Event Not Found" };
+    if (!canManageChurchFromSession(session, event.churchId ?? ""))
+      return { title: "Event Not Found" };
   }
   const description = event.description.slice(0, 160);
   return {
@@ -84,10 +79,8 @@ export default async function EventDetailPage({ params }: Props) {
 
   const isAttending = myAttendance !== null;
 
-  const [canManage, questions] = await Promise.all([
-    canManageChurch(session?.user?.id, session?.user?.role, event.churchId),
-    getEventQuestions(id),
-  ]);
+  const canManage = canManageChurchFromSession(session, event.churchId ?? "");
+  const questions = await getEventQuestions(id);
 
   if (event.isDraft && !canManage) notFound();
 

--- a/app/(app)/(no-nav)/events/[id]/responses/page.tsx
+++ b/app/(app)/(no-nav)/events/[id]/responses/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { getEventById } from "@/lib/actions/data-events";
 import { getEventResponses } from "@/lib/actions/data-questions";
-import { canManageChurch } from "@/lib/permissions";
+import { canManageChurchFromSession } from "@/lib/permissions";
 import { PageHeader } from "@/components/ui/page-header";
 import { ResponsesTable } from "./_components/responses-table";
 
@@ -22,11 +22,7 @@ export default async function EventResponsesPage({ params }: Props) {
   const event = await getEventById(id);
   if (!event) notFound();
 
-  const canManage = await canManageChurch(
-    session?.user?.id,
-    session?.user?.role,
-    event.churchId
-  );
+  const canManage = canManageChurchFromSession(session, event.churchId ?? "");
   if (!canManage) redirect(`/events/${id}`);
 
   const { questions, attendees } = await getEventResponses(id);

--- a/app/(app)/(no-nav)/events/create/page.tsx
+++ b/app/(app)/(no-nav)/events/create/page.tsx
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { EventWizard } from "./_components/event-wizard";
 import { UserRole } from "@prisma/client";
 import { PageHeader } from "@/components/ui/page-header";
-import { getChurchesByManager } from "@/lib/actions/data-churches";
+import { getChurchesByIds } from "@/lib/actions/data-churches";
 import { getSeriesForEvent } from "@/lib/actions/data-series";
 import { getQuestionLibraryForUser } from "@/lib/dal/questions";
 
@@ -23,8 +23,12 @@ export default async function CreateEventPage({ searchParams }: Props) {
 
   const { seriesId } = await searchParams;
 
+  const managedIds = [
+    ...(session.user.organiserChurchIds ?? []),
+    ...(session.user.adminChurchIds ?? []),
+  ];
   const [churches, series, libraryItems] = await Promise.all([
-    getChurchesByManager(session.user.id),
+    getChurchesByIds(managedIds),
     seriesId ? getSeriesForEvent(seriesId) : null,
     getQuestionLibraryForUser(session.user.id),
   ]);

--- a/app/(app)/(no-nav)/series/[id]/edit/page.tsx
+++ b/app/(app)/(no-nav)/series/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import { notFound, redirect } from "next/navigation";
 import { auth } from "@/auth";
 import { UserRole } from "@prisma/client";
 import { getSeriesById } from "@/lib/actions/data-series";
-import { getChurchesByManager } from "@/lib/actions/data-churches";
+import { getChurchesByIds } from "@/lib/actions/data-churches";
 import { PageHeader } from "@/components/ui/page-header";
 import { EditSeriesForm } from "./_components/edit-series-form";
 
@@ -21,7 +21,11 @@ export default async function EditSeriesPage({ params }: Props) {
     redirect("/");
   if (!series) notFound();
 
-  const churches = await getChurchesByManager(session.user.id);
+  const managedIds = [
+    ...(session.user.organiserChurchIds ?? []),
+    ...(session.user.adminChurchIds ?? []),
+  ];
+  const churches = await getChurchesByIds(managedIds);
   if (!churches.some((c) => c.id === series.churchId)) notFound();
 
   return (

--- a/app/(app)/(no-nav)/series/[id]/page.tsx
+++ b/app/(app)/(no-nav)/series/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { Church, MapPin, Pencil, Plus, Tag, User } from "lucide-react";
 import { auth } from "@/auth";
 import { getSeriesById, getMySeriesFollow } from "@/lib/actions/data-series";
-import { canManageChurch } from "@/lib/permissions";
+import { canManageChurchFromSession } from "@/lib/permissions";
 import { InfoField } from "@/components/ui/info-field";
 import { HeroBanner } from "@/components/ui/hero-banner";
 import { EventCard } from "@/components/event-card";
@@ -36,11 +36,7 @@ export default async function SeriesDetailPage({ params }: Props) {
 
   if (!series) notFound();
 
-  const canManage = await canManageChurch(
-    session?.user?.id,
-    session?.user?.role,
-    series.churchId
-  );
+  const canManage = canManageChurchFromSession(session, series.churchId);
   const isFollowing = myFollow !== null;
 
   return (

--- a/app/(app)/(no-nav)/series/create/page.tsx
+++ b/app/(app)/(no-nav)/series/create/page.tsx
@@ -3,7 +3,7 @@ import { auth } from "@/auth";
 import { UserRole } from "@prisma/client";
 import { CreateSeriesForm } from "./_components/create-series-form";
 import { PageHeader } from "@/components/ui/page-header";
-import { getChurchesByManager } from "@/lib/actions/data-churches";
+import { getChurchesByIds } from "@/lib/actions/data-churches";
 
 export default async function CreateSeriesPage() {
   const session = await auth();
@@ -15,7 +15,11 @@ export default async function CreateSeriesPage() {
     redirect("/");
   }
 
-  const churches = await getChurchesByManager(session.user.id);
+  const managedIds = [
+    ...(session.user.organiserChurchIds ?? []),
+    ...(session.user.adminChurchIds ?? []),
+  ];
+  const churches = await getChurchesByIds(managedIds);
 
   return (
     <div className="mx-auto max-w-lg">

--- a/auth.ts
+++ b/auth.ts
@@ -7,6 +7,23 @@ import { authConfig } from "./auth.config";
 import { loginSchema } from "@/lib/validations/auth";
 import type { UserRole } from "@prisma/client";
 
+async function fetchChurchMemberships(userId: string) {
+  const [organiserRows, adminRows] = await Promise.all([
+    prisma.churchOrganiser.findMany({
+      where: { userId },
+      select: { churchId: true },
+    }),
+    prisma.churchAdmin.findMany({
+      where: { userId },
+      select: { churchId: true },
+    }),
+  ]);
+  return {
+    organiserChurchIds: organiserRows.map((r) => r.churchId),
+    adminChurchIds: adminRows.map((r) => r.churchId),
+  };
+}
+
 export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
   adapter: PrismaAdapter(prisma),
@@ -40,6 +57,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     ...authConfig.callbacks,
     async jwt({ token, user, trigger, session }) {
       if (user) {
+        if (!user.id) return token;
+        const memberships = await fetchChurchMemberships(user.id);
         token.id = user.id;
         token.role = (user as { role?: UserRole }).role;
         token.onboardingCompleted =
@@ -47,22 +66,42 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           false;
         token.isEmailVerified = !!(user as { emailVerified?: Date | null })
           .emailVerified;
+        token.organiserChurchIds = memberships.organiserChurchIds;
+        token.adminChurchIds = memberships.adminChurchIds;
+        return token;
       }
       if (trigger === "update" && session?.onboardingCompleted !== undefined) {
         token.onboardingCompleted = session.onboardingCompleted;
+        return token;
+      }
+      // Re-fetch from DB once per hour OR when church IDs haven't been populated yet
+      const now = Math.floor(Date.now() / 1000);
+      if (token.id && (token.organiserChurchIds === undefined || now - (token.iat ?? 0) > 60 * 60)) {
+        const [freshUser, memberships] = await Promise.all([
+          prisma.user.findUnique({
+            where: { id: token.id },
+            select: { role: true, onboardingCompleted: true, emailVerified: true },
+          }),
+          fetchChurchMemberships(token.id),
+        ]);
+        if (freshUser) {
+          token.role = freshUser.role;
+          token.onboardingCompleted = freshUser.onboardingCompleted;
+          token.isEmailVerified = !!freshUser.emailVerified;
+          token.organiserChurchIds = memberships.organiserChurchIds;
+          token.adminChurchIds = memberships.adminChurchIds;
+        }
       }
       return token;
     },
     async session({ session, token }) {
-      if (token.id && session.user) {
-        session.user.id = token.id;
-      }
-      if (token.role && session.user) {
-        session.user.role = token.role;
-      }
+      if (token.id && session.user) session.user.id = token.id;
+      if (token.role && session.user) session.user.role = token.role;
       if (session.user) {
         session.user.onboardingCompleted = token.onboardingCompleted;
         session.user.isEmailVerified = token.isEmailVerified ?? false;
+        session.user.organiserChurchIds = token.organiserChurchIds ?? [];
+        session.user.adminChurchIds = token.adminChurchIds ?? [];
       }
       return session;
     },

--- a/lib/actions/__tests__/data.test.ts
+++ b/lib/actions/__tests__/data.test.ts
@@ -36,7 +36,7 @@ import {
   getChurches,
   getChurchById,
   getMyChurchFollow,
-  getChurchesByManager,
+  getChurchesByIds,
   getOrganisersByChurch,
 } from "@/lib/actions/data-churches";
 import {
@@ -62,7 +62,7 @@ const mockSeriesFindMany = prisma.series.findMany as jest.Mock;
 const mockSeriesFindUnique = prisma.series.findUnique as jest.Mock;
 const mockChurchOrganiserFindMany = prisma.churchOrganiser
   .findMany as jest.Mock;
-const mockChurchAdminFindMany = prisma.churchAdmin.findMany as jest.Mock;
+const _mockChurchAdminFindMany = prisma.churchAdmin.findMany as jest.Mock;
 const mockEventAttendeeFindMany = prisma.eventAttendee.findMany as jest.Mock;
 const mockEventAttendeeFindUnique = prisma.eventAttendee
   .findUnique as jest.Mock;
@@ -199,42 +199,30 @@ describe("getOrganisersByChurch", () => {
   });
 });
 
-describe("getChurchesByManager", () => {
-  it("merges and deduplicates churches from both organiser and admin tables, sorted by name", async () => {
-    mockChurchOrganiserFindMany.mockResolvedValue([
-      { church: { id: "ch-1", name: "Grace Church" } },
-    ]);
-    mockChurchAdminFindMany.mockResolvedValue([
-      { church: { id: "ch-2", name: "Harvest Church" } },
+describe("getChurchesByIds", () => {
+  it("returns churches matching the given IDs ordered by name", async () => {
+    mockChurchFindMany.mockResolvedValue([
+      { id: "ch-1", name: "Grace Church" },
+      { id: "ch-2", name: "Harvest Church" },
     ]);
 
-    const result = await getChurchesByManager("user-1");
+    const result = await getChurchesByIds(["ch-1", "ch-2"]);
 
     expect(result).toEqual([
       { id: "ch-1", name: "Grace Church" },
       { id: "ch-2", name: "Harvest Church" },
     ]);
+    expect(mockChurchFindMany).toHaveBeenCalledWith({
+      where: { id: { in: ["ch-1", "ch-2"] } },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
   });
 
-  it("deduplicates when the same church appears in both tables", async () => {
-    mockChurchOrganiserFindMany.mockResolvedValue([
-      { church: { id: "ch-1", name: "Grace Church" } },
-    ]);
-    mockChurchAdminFindMany.mockResolvedValue([
-      { church: { id: "ch-1", name: "Grace Church" } },
-    ]);
-
-    const result = await getChurchesByManager("user-1");
-
-    expect(result).toHaveLength(1);
-    expect(result[0].id).toBe("ch-1");
-  });
-
-  it("returns empty array when user has no assignments in either table", async () => {
-    mockChurchOrganiserFindMany.mockResolvedValue([]);
-    mockChurchAdminFindMany.mockResolvedValue([]);
-
-    expect(await getChurchesByManager("user-none")).toEqual([]);
+  it("returns empty array without hitting the DB when ids is empty", async () => {
+    const result = await getChurchesByIds([]);
+    expect(result).toEqual([]);
+    expect(mockChurchFindMany).not.toHaveBeenCalled();
   });
 });
 

--- a/lib/actions/__tests__/events.test.ts
+++ b/lib/actions/__tests__/events.test.ts
@@ -56,7 +56,7 @@ jest.mock("@/auth", () => ({
 }));
 
 jest.mock("@/lib/permissions", () => ({
-  canManageChurch: jest.fn(),
+  canManageFromClaims: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock("@/lib/dal/questions", () => ({
@@ -90,7 +90,6 @@ import {
 import { extractResponses } from "@/lib/utils/forms";
 import { prisma } from "@/lib/db";
 import { auth } from "@/auth";
-import { canManageChurch } from "@/lib/permissions";
 import {
   registerEvent as _registerEvent,
   attendEvent as _attendEvent,
@@ -111,7 +110,8 @@ const mockSeriesFollowerFindMany = prisma.seriesFollower.findMany as jest.Mock;
 const mockQueueNotification = jest.requireMock("@/lib/notifications/queue")
   .queueNotification as jest.Mock;
 const mockAuth = auth as jest.Mock;
-const mockCanManageChurch = canManageChurch as jest.Mock;
+const mockCanManageFromClaims = jest.requireMock("@/lib/permissions")
+  .canManageFromClaims as jest.Mock;
 const mockRegisterEvent = _registerEvent as jest.Mock;
 const mockAttendEvent = _attendEvent as jest.Mock;
 const mockUnattendEvent = _unattendEvent as jest.Mock;
@@ -138,8 +138,10 @@ const validData = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockAuth.mockResolvedValue({ user: { id: "user-1", role: "ORGANISER" } });
-  mockCanManageChurch.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({
+    user: { id: "user-1", role: "ORGANISER", organiserChurchIds: [], adminChurchIds: [] },
+  });
+  mockCanManageFromClaims.mockReturnValue(true);
   mockSeriesFollowerFindMany.mockResolvedValue([]);
   mockEventAttendeeFindMany.mockResolvedValue([]);
   mockEventAttendeeFindUnique.mockResolvedValue(null); // not already registered by default
@@ -269,7 +271,7 @@ describe("createEventAction", () => {
   });
 
   it("returns an error when organiser is not assigned to the church", async () => {
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
 
     const result = await createEventAction(validData);
 
@@ -420,7 +422,7 @@ describe("cancelEventAction", () => {
 
   it("redirects away when the user cannot manage the church", async () => {
     mockEventFindUnique.mockResolvedValue({ churchId: "ch-1" });
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
     mockRedirect.mockImplementationOnce(() => {
       throw new Error("NEXT_REDIRECT");
     });
@@ -728,7 +730,7 @@ describe("updateEventAction", () => {
 
   it("redirects away when the organiser cannot manage the original church", async () => {
     mockEventFindUnique.mockResolvedValue(existingPublished);
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
     mockRedirect.mockImplementationOnce(() => {
       throw new Error("NEXT_REDIRECT");
     });
@@ -824,10 +826,10 @@ describe("updateEventAction", () => {
 
   it("checks new church permission when church changes", async () => {
     mockEventFindUnique.mockResolvedValue(existingPublished);
-    // First canManageChurch call (original church) returns true, second (new church) returns false
-    mockCanManageChurch
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+    // First canManageFromClaims call (original church) returns true, second (new church) returns false
+    mockCanManageFromClaims
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
     mockRedirect.mockImplementationOnce(() => {
       throw new Error("NEXT_REDIRECT");
     });
@@ -917,7 +919,7 @@ describe("deleteEventAction", () => {
 
   it("redirects away when the organiser cannot manage the church", async () => {
     mockEventFindUnique.mockResolvedValue({ churchId: "ch-1" });
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
     mockRedirect.mockImplementationOnce(() => {
       throw new Error("NEXT_REDIRECT");
     });
@@ -1027,7 +1029,7 @@ describe("publishEventAction", () => {
       title: "Test",
       isDraft: true,
     });
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
 
     const result = await publishEventAction("evt-1");
 
@@ -1219,7 +1221,7 @@ describe("unpublishEventAction", () => {
 
   it("returns an error when the organiser cannot manage the church", async () => {
     mockEventFindUnique.mockResolvedValue({ churchId: "ch-1" });
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
 
     const result = await unpublishEventAction("evt-1");
 

--- a/lib/actions/__tests__/series.test.ts
+++ b/lib/actions/__tests__/series.test.ts
@@ -26,7 +26,7 @@ jest.mock("@/auth", () => ({
 }));
 
 jest.mock("@/lib/permissions", () => ({
-  canManageChurch: jest.fn(),
+  canManageFromClaims: jest.fn().mockReturnValue(true),
 }));
 
 import { redirect } from "next/navigation";
@@ -40,7 +40,6 @@ import {
 } from "@/lib/actions/series";
 import { prisma } from "@/lib/db";
 import { auth } from "@/auth";
-import { canManageChurch } from "@/lib/permissions";
 
 const mockRedirect = redirect as unknown as jest.Mock;
 const mockUpdateTag = updateTag as jest.Mock;
@@ -51,7 +50,8 @@ const mockSeriesFindUnique = prisma.series.findUnique as jest.Mock;
 const mockSeriesFollowerCreate = prisma.seriesFollower.create as jest.Mock;
 const mockSeriesFollowerDelete = prisma.seriesFollower.delete as jest.Mock;
 const mockAuth = auth as jest.Mock;
-const mockCanManageChurch = canManageChurch as jest.Mock;
+const mockCanManageFromClaims = jest.requireMock("@/lib/permissions")
+  .canManageFromClaims as jest.Mock;
 
 const validData = {
   name: "Weekly Bible Study",
@@ -65,8 +65,10 @@ const validData = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockAuth.mockResolvedValue({ user: { id: "user-1", role: "ORGANISER" } });
-  mockCanManageChurch.mockResolvedValue(true);
+  mockAuth.mockResolvedValue({
+    user: { id: "user-1", role: "ORGANISER", organiserChurchIds: [], adminChurchIds: [] },
+  });
+  mockCanManageFromClaims.mockReturnValue(true);
 });
 
 describe("createSeriesAction", () => {
@@ -147,7 +149,7 @@ describe("createSeriesAction", () => {
   });
 
   it("returns an error when organiser is not assigned to the church", async () => {
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
 
     const result = await createSeriesAction(validData);
 
@@ -308,7 +310,7 @@ describe("updateSeriesAction", () => {
   });
 
   it("redirects to /organiser when organiser is not assigned to the church", async () => {
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
     mockRedirect.mockImplementationOnce(() => {
       throw new Error("NEXT_REDIRECT");
     });
@@ -362,7 +364,7 @@ describe("deleteSeriesAction", () => {
   });
 
   it("redirects to /organiser when organiser is not assigned to the church", async () => {
-    mockCanManageChurch.mockResolvedValue(false);
+    mockCanManageFromClaims.mockReturnValue(false);
     mockRedirect.mockImplementationOnce(() => {
       throw new Error("NEXT_REDIRECT");
     });

--- a/lib/actions/data-churches.ts
+++ b/lib/actions/data-churches.ts
@@ -53,28 +53,15 @@ export async function getMyChurchFollow(churchId: string, userId: string) {
   });
 }
 
-export async function getChurchesByManager(userId: string) {
-  cacheTag("churches", `user-churches-${userId}`);
+export async function getChurchesByIds(ids: string[]) {
+  if (ids.length === 0) return [];
+  cacheTag("churches");
   cacheLife("hours");
-  const [organiserRows, adminRows] = await Promise.all([
-    prisma.churchOrganiser.findMany({
-      where: { userId },
-      select: { church: { select: { id: true, name: true } } },
-    }),
-    prisma.churchAdmin.findMany({
-      where: { userId },
-      select: { church: { select: { id: true, name: true } } },
-    }),
-  ]);
-  const seen = new Set<string>();
-  const churches: Array<{ id: string; name: string }> = [];
-  for (const row of [...organiserRows, ...adminRows]) {
-    if (!seen.has(row.church.id)) {
-      seen.add(row.church.id);
-      churches.push(row.church);
-    }
-  }
-  return churches.sort((a, b) => a.name.localeCompare(b.name));
+  return prisma.church.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, name: true },
+    orderBy: { name: "asc" },
+  });
 }
 
 export async function getOrganisersByChurch(churchId: string) {

--- a/lib/actions/events-crud.ts
+++ b/lib/actions/events-crud.ts
@@ -42,7 +42,9 @@ export async function createEventAction(
   const result = await createEvent(
     parsed.data,
     session.user.id,
-    session.user.role
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
   );
   if ("error" in result || "fieldErrors" in result) return result;
 
@@ -77,7 +79,9 @@ export async function updateEventAction(
     id,
     parsed.data,
     session.user.id,
-    session.user.role
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
   );
   if ("error" in result) redirect("/organiser");
   if ("fieldErrors" in result) return result;
@@ -101,7 +105,9 @@ export async function cancelEventAction(
     id,
     reason,
     session.user.id,
-    session.user.role
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
   );
   if ("error" in result) redirect("/organiser");
 
@@ -117,7 +123,13 @@ export async function uncancelEventAction(id: string): Promise<void> {
   )
     redirect("/");
 
-  const result = await uncancelEvent(id, session.user.id, session.user.role);
+  const result = await uncancelEvent(
+    id,
+    session.user.id,
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
+  );
   if ("error" in result) redirect("/organiser");
 
   invalidateEventCaches(id, result.churchId, result.seriesId);
@@ -133,7 +145,13 @@ export async function publishEventAction(id: string): Promise<ActionResult> {
     return { error: "Unauthorised." };
   }
 
-  const result = await publishEvent(id, session.user.id, session.user.role);
+  const result = await publishEvent(
+    id,
+    session.user.id,
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
+  );
   if ("error" in result) return result;
 
   invalidateEventCaches(id, result.churchId, result.seriesId, {
@@ -151,7 +169,13 @@ export async function unpublishEventAction(id: string): Promise<ActionResult> {
     return { error: "Unauthorised." };
   }
 
-  const result = await unpublishEvent(id, session.user.id, session.user.role);
+  const result = await unpublishEvent(
+    id,
+    session.user.id,
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
+  );
   if ("error" in result) return result;
 
   invalidateEventCaches(id, result.churchId, result.seriesId, {
@@ -181,11 +205,16 @@ export async function saveDraftAction(
     questions: parsed.data.questions ?? [],
   };
 
+  const organiserIds = session.user.organiserChurchIds ?? [];
+  const adminIds = session.user.adminChurchIds ?? [];
+
   if (!id) {
     const result = await createEvent(
       { ...dataWithDefaults, isDraft: true },
       session.user.id,
-      session.user.role
+      session.user.role,
+      organiserIds,
+      adminIds
     );
     if ("error" in result || "fieldErrors" in result) return result;
     invalidateEventCaches(result.id, result.churchId, result.seriesId ?? null);
@@ -195,7 +224,9 @@ export async function saveDraftAction(
       id,
       { ...dataWithDefaults, isDraft: dataWithDefaults.isDraft ?? true },
       session.user.id,
-      session.user.role
+      session.user.role,
+      organiserIds,
+      adminIds
     );
     if ("error" in result || "fieldErrors" in result) return result;
     invalidateEventUpdate(id, result);
@@ -223,7 +254,9 @@ export async function saveEventAction(
     id,
     parsed.data,
     session.user.id,
-    session.user.role
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
   );
   if ("error" in result || "fieldErrors" in result) return result;
 
@@ -240,7 +273,13 @@ export async function deleteEventAction(id: string): Promise<void> {
   )
     redirect("/");
 
-  const result = await deleteEvent(id, session.user.id, session.user.role);
+  const result = await deleteEvent(
+    id,
+    session.user.id,
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
+  );
   if ("error" in result) redirect("/organiser");
 
   invalidateEventCaches(id, result.churchId, result.seriesId, {

--- a/lib/actions/series.ts
+++ b/lib/actions/series.ts
@@ -35,7 +35,9 @@ export async function createSeriesAction(
   const result = await createSeries(
     parsed.data,
     session.user.id,
-    session.user.role
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
   );
   if ("error" in result || "fieldErrors" in result) return result;
 
@@ -62,7 +64,9 @@ export async function updateSeriesAction(
     id,
     parsed.data,
     session.user.id,
-    session.user.role
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
   );
   if ("error" in result || "fieldErrors" in result) redirect("/organiser");
 
@@ -126,7 +130,13 @@ export async function deleteSeriesAction(id: string): Promise<void> {
   )
     redirect("/");
 
-  const result = await deleteSeries(id, session.user.id, session.user.role);
+  const result = await deleteSeries(
+    id,
+    session.user.id,
+    session.user.role,
+    session.user.organiserChurchIds ?? [],
+    session.user.adminChurchIds ?? []
+  );
   if ("error" in result) redirect("/organiser");
 
   broadcastSeriesChange(id, result.churchId);

--- a/lib/dal/__tests__/events.test.ts
+++ b/lib/dal/__tests__/events.test.ts
@@ -24,7 +24,7 @@ jest.mock("@/lib/notifications/queue", () => ({
 }));
 
 jest.mock("@/lib/permissions", () => ({
-  canManageChurch: jest.fn().mockResolvedValue(true),
+  canManageFromClaims: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock("@/lib/dal/questions", () => ({
@@ -59,7 +59,7 @@ describe("notifySeriesFollowers deduplication", () => {
       { userId: "user-2" },
     ]);
 
-    await publishEvent("evt-1", "admin-user", "ADMIN");
+    await publishEvent("evt-1", "admin-user", "ADMIN", [], ["ch-1"]);
 
     expect(mockPrisma.notification.createMany).not.toHaveBeenCalled();
     expect(mockQueue.queueNotification).toHaveBeenCalledWith(
@@ -95,7 +95,7 @@ describe("notifyEventAttendees deduplication", () => {
       { userId: "user-4" },
     ]);
 
-    await cancelEvent("evt-2", "Venue unavailable", "admin-user", "ADMIN");
+    await cancelEvent("evt-2", "Venue unavailable", "admin-user", "ADMIN", [], ["ch-1"]);
 
     expect(mockPrisma.notification.createMany).not.toHaveBeenCalled();
     expect(mockQueue.queueNotification).toHaveBeenCalledWith(

--- a/lib/dal/events.ts
+++ b/lib/dal/events.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { prisma } from "@/lib/db";
 import { NotificationType } from "@prisma/client";
-import { canManageChurch } from "@/lib/permissions";
+import { canManageFromClaims } from "@/lib/permissions";
 import { syncEventQuestions } from "@/lib/dal/questions";
 import {
   cancelManyNotifications,
@@ -69,7 +69,9 @@ type DalError = { error: string } | { fieldErrors: Record<string, string[]> };
 export async function createEvent(
   data: CreateEventInput,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   | DalError
   | {
@@ -124,7 +126,7 @@ export async function createEvent(
 
   if (!churchId) return { fieldErrors: { churchId: ["Church is required"] } };
 
-  const allowed = await canManageChurch(userId, userRole, churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, churchId);
   if (!allowed) return { error: "You are not assigned to this church." };
 
   const isCamp = tag === "Camp";
@@ -192,7 +194,9 @@ export async function updateEvent(
   id: string,
   data: CreateEventInput,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   | DalError
   | {
@@ -252,15 +256,11 @@ export async function updateEvent(
   });
   if (!existing) return { error: "Event not found." };
 
-  const allowedOriginal = await canManageChurch(
-    userId,
-    userRole,
-    existing.churchId
-  );
+  const allowedOriginal = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, existing.churchId);
   if (!allowedOriginal) return { error: "Unauthorised." };
 
   if (churchId !== existing.churchId) {
-    const allowedNew = await canManageChurch(userId, userRole, churchId);
+    const allowedNew = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, churchId);
     if (!allowedNew) return { error: "Unauthorised." };
   }
 
@@ -338,7 +338,9 @@ export async function cancelEvent(
   id: string,
   reason: string,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   { error: string } | { churchId: string | null; seriesId: string | null }
 > {
@@ -348,7 +350,7 @@ export async function cancelEvent(
   });
   if (!event) return { error: "Event not found." };
 
-  const allowed = await canManageChurch(userId, userRole, event.churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, event.churchId);
   if (!allowed) return { error: "Unauthorised." };
 
   await prisma.event.update({
@@ -372,7 +374,9 @@ export async function cancelEvent(
 export async function uncancelEvent(
   id: string,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   { error: string } | { churchId: string | null; seriesId: string | null }
 > {
@@ -382,7 +386,7 @@ export async function uncancelEvent(
   });
   if (!event) return { error: "Event not found." };
 
-  const allowed = await canManageChurch(userId, userRole, event.churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, event.churchId);
   if (!allowed) return { error: "Unauthorised." };
 
   await prisma.event.update({
@@ -396,7 +400,9 @@ export async function uncancelEvent(
 export async function publishEvent(
   id: string,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   | { error: string }
   | {
@@ -417,7 +423,7 @@ export async function publishEvent(
   });
   if (!event) return { error: "Event not found." };
 
-  const allowed = await canManageChurch(userId, userRole, event.churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, event.churchId);
   if (!allowed) return { error: "You are not assigned to this church." };
 
   if (!event.isDraft) {
@@ -465,7 +471,9 @@ export async function publishEvent(
 export async function unpublishEvent(
   id: string,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   { error: string } | { churchId: string | null; seriesId: string | null }
 > {
@@ -475,7 +483,7 @@ export async function unpublishEvent(
   });
   if (!event) return { error: "Event not found." };
 
-  const allowed = await canManageChurch(userId, userRole, event.churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, event.churchId);
   if (!allowed) return { error: "You are not assigned to this church." };
 
   await prisma.event.update({ where: { id }, data: { isDraft: true } });
@@ -501,7 +509,9 @@ export async function unpublishEvent(
 export async function deleteEvent(
   id: string,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<
   { error: string } | { churchId: string | null; seriesId: string | null }
 > {
@@ -511,7 +521,7 @@ export async function deleteEvent(
   });
   if (!event) return { error: "Event not found." };
 
-  const allowed = await canManageChurch(userId, userRole, event.churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, event.churchId);
   if (!allowed) return { error: "Unauthorised." };
 
   try {

--- a/lib/dal/series.ts
+++ b/lib/dal/series.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { prisma } from "@/lib/db";
-import { canManageChurch } from "@/lib/permissions";
+import { canManageFromClaims } from "@/lib/permissions";
 import type { CreateSeriesInput } from "@/lib/validations/series";
 
 type DalError = { error: string } | { fieldErrors: Record<string, string[]> };
@@ -9,7 +9,9 @@ type DalError = { error: string } | { fieldErrors: Record<string, string[]> };
 export async function createSeries(
   data: CreateSeriesInput,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<DalError | { id: string; churchId: string }> {
   const {
     name,
@@ -22,7 +24,7 @@ export async function createSeries(
     photoUrl,
   } = data;
 
-  const allowed = await canManageChurch(userId, userRole, churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, churchId);
   if (!allowed) return { error: "You are not assigned to this church." };
 
   const created = await prisma.series.create({
@@ -46,7 +48,9 @@ export async function updateSeries(
   id: string,
   data: CreateSeriesInput,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<DalError | { oldChurchId: string; newChurchId: string }> {
   const {
     name,
@@ -65,15 +69,11 @@ export async function updateSeries(
   });
   if (!existing) return { error: "Series not found." };
 
-  const allowedOriginal = await canManageChurch(
-    userId,
-    userRole,
-    existing.churchId
-  );
+  const allowedOriginal = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, existing.churchId);
   if (!allowedOriginal) return { error: "Unauthorised." };
 
   if (churchId !== existing.churchId) {
-    const allowedNew = await canManageChurch(userId, userRole, churchId);
+    const allowedNew = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, churchId);
     if (!allowedNew) return { error: "Unauthorised." };
   }
 
@@ -97,7 +97,9 @@ export async function updateSeries(
 export async function deleteSeries(
   id: string,
   userId: string,
-  userRole: string
+  userRole: string,
+  organiserChurchIds: string[],
+  adminChurchIds: string[]
 ): Promise<{ error: string } | { churchId: string }> {
   const series = await prisma.series.findUnique({
     where: { id },
@@ -105,7 +107,7 @@ export async function deleteSeries(
   });
   if (!series) return { error: "Series not found." };
 
-  const allowed = await canManageChurch(userId, userRole, series.churchId);
+  const allowed = canManageFromClaims(userRole, organiserChurchIds, adminChurchIds, series.churchId);
   if (!allowed) return { error: "Unauthorised." };
 
   await prisma.series.delete({ where: { id } });

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -1,5 +1,37 @@
 import "server-only";
 import { prisma } from "@/lib/db";
+import type { Session } from "next-auth";
+
+/**
+ * Token-based permission check using raw claims arrays — no DB hit.
+ * Use in DAL functions that receive organiserChurchIds/adminChurchIds from server actions.
+ */
+export function canManageFromClaims(
+  role: string | null | undefined,
+  organiserChurchIds: string[],
+  adminChurchIds: string[],
+  churchId: string | null | undefined
+): boolean {
+  if (!churchId) return false;
+  if (role === "ORGANISER") return organiserChurchIds.includes(churchId);
+  if (role === "ADMIN") return adminChurchIds.includes(churchId);
+  return false;
+}
+
+/**
+ * Token-based permission check — no DB hit.
+ * Use for page renders and read paths; keep DB checks for destructive admin actions.
+ */
+export function canManageChurchFromSession(
+  session: Session | null,
+  churchId: string
+): boolean {
+  if (!session?.user) return false;
+  const { role, organiserChurchIds = [], adminChurchIds = [] } = session.user;
+  if (role === "ORGANISER") return organiserChurchIds.includes(churchId);
+  if (role === "ADMIN") return adminChurchIds.includes(churchId);
+  return false;
+}
 
 /**
  * Returns true if the user has an explicit ChurchAdmin assignment

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -9,6 +9,8 @@ declare module "next-auth" {
       role: UserRole;
       onboardingCompleted?: boolean;
       isEmailVerified?: boolean;
+      organiserChurchIds: string[];
+      adminChurchIds: string[];
     } & DefaultSession["user"];
   }
 }
@@ -19,5 +21,7 @@ declare module "next-auth/jwt" {
     role?: UserRole;
     onboardingCompleted?: boolean;
     isEmailVerified?: boolean;
+    organiserChurchIds?: string[];
+    adminChurchIds?: string[];
   }
 }


### PR DESCRIPTION
…DB queries

organiserChurchIds and adminChurchIds now stored in JWT claims, re-fetched on sign-in and on the hourly token re-issue cycle. Also backfills missing claims for pre-deploy sessions on next auth() call.

- Replace getChurchesByManager (DB join) with getChurchesByIds (token IDs)
- Add canManageFromClaims / canManageChurchFromSession (sync, no DB hit)
- Thread organiserChurchIds / adminChurchIds through all DAL call sites
- Drop async canManageChurch from page renders and server actions