### PR TITLE
perf: improve LCP on home page

### DIFF
--- a/components/event-card.tsx
+++ b/components/event-card.tsx
@@ -32,8 +32,10 @@ export function EventCard({ event, priority = false }: EventCardProps) {
                 alt=""
                 fill
                 className="object-cover"
-                sizes="(max-width: 768px) 100vw, 50vw"
+                sizes="(max-width: 640px) 100vw, 50vw"
                 priority={priority}
+                placeholder="blur"
+                blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8e+/+fwAI9AN2hc9PNgAAAABJRU5ErkJggg=="
               />
             </div>
           )}

--- a/lib/actions/__tests__/data.test.ts
+++ b/lib/actions/__tests__/data.test.ts
@@ -904,22 +904,15 @@ describe("getEventsNotByCreatorPaged", () => {
 
 describe("getFollowedChurchEventsPaged", () => {
   it("returns events from followed churches, first page", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([
-      { churchId: "ch-1" },
-      { churchId: "ch-2" },
-    ]);
     mockEventFindMany.mockResolvedValue([sampleEvent]);
 
     const result = await getFollowedChurchEventsPaged("user-1", null);
 
-    expect(mockChurchFollowerFindMany).toHaveBeenCalledWith({
-      where: { userId: "user-1" },
-      select: { churchId: true },
-    });
+    expect(mockChurchFollowerFindMany).not.toHaveBeenCalled();
     expect(mockEventFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          churchId: { in: ["ch-1", "ch-2"] },
+          church: { followers: { some: { userId: "user-1" } } },
           isDraft: false,
           datetime: { gte: expect.any(Date) },
         }),
@@ -932,7 +925,6 @@ describe("getFollowedChurchEventsPaged", () => {
   });
 
   it("returns nextCursor when more pages exist", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([{ churchId: "ch-1" }]);
     const events = Array.from({ length: 11 }, (_, i) => ({
       ...sampleEvent,
       id: `evt-${i}`,
@@ -946,7 +938,6 @@ describe("getFollowedChurchEventsPaged", () => {
   });
 
   it("passes cursor when provided", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([{ churchId: "ch-1" }]);
     mockEventFindMany.mockResolvedValue([sampleEvent]);
 
     await getFollowedChurchEventsPaged("user-1", "cursor-id");
@@ -960,7 +951,6 @@ describe("getFollowedChurchEventsPaged", () => {
   });
 
   it("returns empty page when user follows no churches", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([]);
     mockEventFindMany.mockResolvedValue([]);
 
     const result = await getFollowedChurchEventsPaged("user-1", null);
@@ -972,15 +962,15 @@ describe("getFollowedChurchEventsPaged", () => {
 
 describe("getOtherChurchEventsPaged", () => {
   it("excludes followed church events for authenticated user", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([{ churchId: "ch-1" }]);
     mockEventFindMany.mockResolvedValue([sampleEvent]);
 
     const result = await getOtherChurchEventsPaged("user-1", null);
 
+    expect(mockChurchFollowerFindMany).not.toHaveBeenCalled();
     expect(mockEventFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          churchId: { notIn: ["ch-1"] },
+          church: { followers: { none: { userId: "user-1" } } },
           isDraft: false,
           datetime: { gte: expect.any(Date) },
         }),
@@ -998,7 +988,8 @@ describe("getOtherChurchEventsPaged", () => {
     expect(mockEventFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          churchId: { notIn: [] },
+          isDraft: false,
+          datetime: { gte: expect.any(Date) },
         }),
       })
     );
@@ -1006,7 +997,6 @@ describe("getOtherChurchEventsPaged", () => {
   });
 
   it("returns nextCursor when more pages exist", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([]);
     const events = Array.from({ length: 11 }, (_, i) => ({
       ...sampleEvent,
       id: `evt-${i}`,
@@ -1020,7 +1010,6 @@ describe("getOtherChurchEventsPaged", () => {
   });
 
   it("passes cursor when provided", async () => {
-    mockChurchFollowerFindMany.mockResolvedValue([]);
     mockEventFindMany.mockResolvedValue([sampleEvent]);
 
     await getOtherChurchEventsPaged("user-1", "cursor-id");

--- a/lib/actions/data-events.ts
+++ b/lib/actions/data-events.ts
@@ -245,15 +245,9 @@ export async function getFollowedChurchEventsPaged(
 ): Promise<{ items: EventCardItem[]; nextCursor: string | null }> {
   cacheTag("events-list", `user-follows-${userId}`);
   cacheLife("minutes");
-  const follows = await prisma.churchFollower.findMany({
-    where: { userId },
-    select: { churchId: true },
-  });
-  const churchIds = follows.map((f) => f.churchId);
-  if (churchIds.length === 0) return { items: [], nextCursor: null };
   const rows = await prisma.event.findMany({
     where: {
-      churchId: { in: churchIds },
+      church: { followers: { some: { userId } } },
       datetime: { gte: new Date() },
       isDraft: false,
     },
@@ -279,15 +273,11 @@ export async function getOtherChurchEventsPaged(
     cacheTag("events-list");
   }
   cacheLife("minutes");
-  const excludedIds =
-    userId === null
-      ? []
-      : await prisma.churchFollower
-          .findMany({ where: { userId }, select: { churchId: true } })
-          .then((rows) => rows.map((r) => r.churchId));
   const rows = await prisma.event.findMany({
     where: {
-      churchId: { notIn: excludedIds },
+      ...(userId !== null
+        ? { church: { followers: { none: { userId } } } }
+        : {}),
       datetime: { gte: new Date() },
       isDraft: false,
     },

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const nextConfig: NextConfig = {
     "192.168.0.3", // physical device on LAN
   ],
   images: {
+    minimumCacheTTL: 60 * 60 * 24 * 7, // 7 days — optimized images are immutable for a given URL
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
- Collapse two sequential DB queries into one in getFollowedChurchEventsPaged and getOtherChurchEventsPaged using Prisma relation filters (some/none), saving a DB roundtrip per call on every home page load
- Add blur placeholder to EventCard images so LCP element is visible immediately rather than blank until download completes
- Tighten image sizes hint from 768px to 640px breakpoint for mobile-first layout
- Set minimumCacheTTL to 7 days for next/image since Vercel Blob URLs are content-addressed and the optimised variant never changes
- Update tests to assert new single-query shape and no follower pre-fetch