### PR TITLE
perf(home): reduce LCP via streaming and query optimization

### DIFF
--- a/app/(app)/(with-nav)/page.tsx
+++ b/app/(app)/(with-nav)/page.tsx
@@ -1,6 +1,8 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { MapPin, SearchX } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EventCard } from "@/domains/events/components/event-card";
 import { searchEventsAndChurches } from "@/domains/profile/actions/data";
 import {
@@ -12,10 +14,23 @@ import {
   loadMoreOtherEventsAction,
 } from "@/domains/events/actions/pagination";
 import { PageHeader } from "@/components/ui/page-header";
-import { WHEN_LABELS, TYPE_LABELS, type WhenFilter } from "@/lib/types/search";
+import {
+  WHEN_LABELS,
+  TYPE_LABELS,
+  type WhenFilter,
+  type TypeFilter,
+} from "@/lib/types/search";
 import { searchParamsSchema } from "@/lib/validations/search";
 import { HomeEventTabs } from "@/domains/events/components/home-event-tabs";
 import { auth } from "@/auth";
+
+interface HomeContentProps {
+  query: string;
+  type: TypeFilter;
+  when: string | undefined;
+  category: string | undefined;
+  hasFilters: boolean;
+}
 
 export default async function Home({
   searchParams,
@@ -33,39 +48,12 @@ export default async function Home({
   const query = q?.trim() ?? "";
   const hasFilters = !!(query || type !== "all" || when || category);
 
-  const userId = hasFilters ? null : ((await auth())?.user?.id ?? null);
-
-  const [searchResults, followedPage, otherPage] = await Promise.all([
-    hasFilters
-      ? searchEventsAndChurches({
-          query,
-          type,
-          when: when as WhenFilter | undefined,
-          category: category ?? "",
-        })
-      : Promise.resolve(null),
-    !hasFilters && userId
-      ? getFollowedChurchEventsPaged(userId, null)
-      : Promise.resolve({ items: [], nextCursor: null }),
-    !hasFilters
-      ? getOtherChurchEventsPaged(userId, null)
-      : Promise.resolve({ items: [], nextCursor: null }),
-  ]);
-
-  const filteredEvents = searchResults?.events ?? null;
-  const filteredChurches = searchResults?.churches ?? null;
-
-  const hasResults =
-    (filteredEvents?.length ?? 0) > 0 || (filteredChurches?.length ?? 0) > 0;
-
   const filterParts = [
     query ? `"${query}"` : null,
     category || null,
     when ? WHEN_LABELS[when as WhenFilter] : null,
     type && type !== "all" ? TYPE_LABELS[type] : null,
   ].filter(Boolean);
-
-  const defaultTab = followedPage.items.length > 0 ? "followed" : "other";
 
   return (
     <div className="flex flex-col">
@@ -75,79 +63,133 @@ export default async function Home({
           filterParts.length ? `Showing: ${filterParts.join(" · ")}` : undefined
         }
       />
-
       <div className="flex flex-col gap-6 px-4 py-2">
-        {hasFilters ? (
-          !hasResults ? (
-            <div className="flex flex-col items-center gap-3 py-16 text-center">
-              <SearchX className="text-muted-foreground/40 size-10" />
-              <p className="text-base font-semibold">No results found</p>
-              <p className="text-muted-foreground text-sm">
-                Try adjusting your filters
-              </p>
-            </div>
-          ) : (
-            <>
-              {filteredEvents && filteredEvents.length > 0 && (
-                <section className="flex flex-col gap-3">
-                  <h2 className="text-base font-semibold">
-                    Events{" "}
-                    <span className="text-muted-foreground text-sm font-normal">
-                      ({filteredEvents.length})
-                    </span>
-                  </h2>
-                  {filteredEvents.map((event, index) => (
-                    <EventCard
-                      key={event.id}
-                      priority={index === 0}
-                      event={{
-                        ...event,
-                        badge: event.tag,
-                        churchName: event.church?.name ?? "",
-                      }}
-                    />
-                  ))}
-                </section>
-              )}
-
-              {filteredChurches && filteredChurches.length > 0 && (
-                <section className="flex flex-col gap-3">
-                  <h2 className="text-base font-semibold">
-                    Churches{" "}
-                    <span className="text-muted-foreground text-sm font-normal">
-                      ({filteredChurches.length})
-                    </span>
-                  </h2>
-                  {filteredChurches.map((church) => (
-                    <Link key={church.id} href={`/churches/${church.id}`}>
-                      <Card className="shadow-card rounded-2xl border-0 bg-white py-0">
-                        <CardContent className="flex items-center justify-between p-4">
-                          <div className="flex flex-col gap-1">
-                            <p className="text-sm font-bold">{church.name}</p>
-                            <p className="text-muted-foreground flex items-center gap-1 text-xs">
-                              <MapPin className="size-3" />
-                              {church.address}
-                            </p>
-                          </div>
-                        </CardContent>
-                      </Card>
-                    </Link>
-                  ))}
-                </section>
-              )}
-            </>
-          )
-        ) : (
-          <HomeEventTabs
-            defaultTab={defaultTab}
-            followedPage={followedPage}
-            otherPage={otherPage}
-            isAuthenticated={!!userId}
-            loadMoreFollowed={loadMoreFollowedEventsAction}
-            loadMoreOther={loadMoreOtherEventsAction}
+        <Suspense fallback={<HomeContentSkeleton />}>
+          <HomeContent
+            query={query}
+            type={type}
+            when={when}
+            category={category}
+            hasFilters={hasFilters}
           />
-        )}
+        </Suspense>
       </div>
     </div>
+  );
+}
+
+function HomeContentSkeleton() {
+  return (
+    <section className="flex flex-col gap-3">
+      <Skeleton className="h-5 w-36" />
+      <Skeleton className="h-24 w-full rounded-2xl" />
+      <Skeleton className="h-24 w-full rounded-2xl" />
+      <Skeleton className="h-24 w-full rounded-2xl" />
+    </section>
+  );
+}
+
+async function HomeContent({
+  query,
+  type,
+  when,
+  category,
+  hasFilters,
+}: HomeContentProps) {
+  if (hasFilters) {
+    const results = await searchEventsAndChurches({
+      query,
+      type,
+      when: when as WhenFilter | undefined,
+      category: category ?? "",
+    });
+
+    const filteredEvents = results?.events ?? null;
+    const filteredChurches = results?.churches ?? null;
+    const hasResults =
+      (filteredEvents?.length ?? 0) > 0 || (filteredChurches?.length ?? 0) > 0;
+
+    if (!hasResults) {
+      return (
+        <div className="flex flex-col items-center gap-3 py-16 text-center">
+          <SearchX className="text-muted-foreground/40 size-10" />
+          <p className="text-base font-semibold">No results found</p>
+          <p className="text-muted-foreground text-sm">
+            Try adjusting your filters
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        {filteredEvents && filteredEvents.length > 0 && (
+          <section className="flex flex-col gap-3">
+            <h2 className="text-base font-semibold">
+              Events{" "}
+              <span className="text-muted-foreground text-sm font-normal">
+                ({filteredEvents.length})
+              </span>
+            </h2>
+            {filteredEvents.map((event, index) => (
+              <EventCard
+                key={event.id}
+                priority={index === 0}
+                event={{
+                  ...event,
+                  badge: event.tag,
+                  churchName: event.church?.name ?? "",
+                }}
+              />
+            ))}
+          </section>
+        )}
+        {filteredChurches && filteredChurches.length > 0 && (
+          <section className="flex flex-col gap-3">
+            <h2 className="text-base font-semibold">
+              Churches{" "}
+              <span className="text-muted-foreground text-sm font-normal">
+                ({filteredChurches.length})
+              </span>
+            </h2>
+            {filteredChurches.map((church) => (
+              <Link key={church.id} href={`/churches/${church.id}`}>
+                <Card className="shadow-card rounded-2xl border-0 bg-white py-0">
+                  <CardContent className="flex items-center justify-between p-4">
+                    <div className="flex flex-col gap-1">
+                      <p className="text-sm font-bold">{church.name}</p>
+                      <p className="text-muted-foreground flex items-center gap-1 text-xs">
+                        <MapPin className="size-3" />
+                        {church.address}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </section>
+        )}
+      </>
+    );
+  }
+
+  const userId = (await auth())?.user?.id ?? null;
+  const [followedPage, otherPage] = await Promise.all([
+    userId
+      ? getFollowedChurchEventsPaged(userId, null)
+      : Promise.resolve({ items: [], nextCursor: null }),
+    getOtherChurchEventsPaged(userId, null),
+  ]);
+  const defaultTab = followedPage.items.length > 0 ? "followed" : "other";
+
+  return (
+    <HomeEventTabs
+      defaultTab={defaultTab}
+      followedPage={followedPage}
+      otherPage={otherPage}
+      isAuthenticated={!!userId}
+      loadMoreFollowed={loadMoreFollowedEventsAction}
+      loadMoreOther={loadMoreOtherEventsAction}
+    />
   );
 }

--- a/domains/events/actions/data.ts
+++ b/domains/events/actions/data.ts
@@ -273,10 +273,25 @@ export async function getOtherChurchEventsPaged(
     cacheTag("events-list");
   }
   cacheLife("minutes");
+
+  // Two-step approach: fetch followed church IDs first (fast index lookup on
+  // ChurchFollower.userId), then exclude with notIn. This avoids the correlated
+  // NOT EXISTS subquery that Prisma generates for `followers: { none: { userId } }`,
+  // which scans the ChurchFollower table for every candidate event row.
+  const excludedChurchIds =
+    userId !== null
+      ? (
+          await prisma.churchFollower.findMany({
+            where: { userId },
+            select: { churchId: true },
+          })
+        ).map((f) => f.churchId)
+      : [];
+
   const rows = await prisma.event.findMany({
     where: {
-      ...(userId !== null
-        ? { church: { followers: { none: { userId } } } }
+      ...(excludedChurchIds.length > 0
+        ? { churchId: { notIn: excludedChurchIds } }
         : {}),
       datetime: { gte: new Date() },
       isDraft: false,

--- a/lib/__tests__/data.test.ts
+++ b/lib/__tests__/data.test.ts
@@ -968,15 +968,19 @@ describe("getFollowedChurchEventsPaged", () => {
 
 describe("getOtherChurchEventsPaged", () => {
   it("excludes followed church events for authenticated user", async () => {
+    mockChurchFollowerFindMany.mockResolvedValue([{ churchId: "church-2" }]);
     mockEventFindMany.mockResolvedValue([sampleEvent]);
 
     const result = await getOtherChurchEventsPaged("user-1", null);
 
-    expect(mockChurchFollowerFindMany).not.toHaveBeenCalled();
+    expect(mockChurchFollowerFindMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+      select: { churchId: true },
+    });
     expect(mockEventFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({
-          church: { followers: { none: { userId: "user-1" } } },
+          churchId: { notIn: ["church-2"] },
           isDraft: false,
           datetime: { gte: expect.any(Date) },
         }),
@@ -1003,6 +1007,7 @@ describe("getOtherChurchEventsPaged", () => {
   });
 
   it("returns nextCursor when more pages exist", async () => {
+    mockChurchFollowerFindMany.mockResolvedValue([]);
     const events = Array.from({ length: 11 }, (_, i) => ({
       ...sampleEvent,
       id: `evt-${i}`,
@@ -1016,6 +1021,7 @@ describe("getOtherChurchEventsPaged", () => {
   });
 
   it("passes cursor when provided", async () => {
+    mockChurchFollowerFindMany.mockResolvedValue([]);
     mockEventFindMany.mockResolvedValue([sampleEvent]);
 
     await getOtherChurchEventsPaged("user-1", "cursor-id");

--- a/prisma/migrations/20260605143657_add_church_follower_church_id_index/migration.sql
+++ b/prisma/migrations/20260605143657_add_church_follower_church_id_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "ChurchFollower_churchId_idx" ON "ChurchFollower"("churchId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -229,6 +229,7 @@ model ChurchFollower {
 
   @@unique([churchId, userId])
   @@index([userId])
+  @@index([churchId])
 }
 
 model SeriesFollower {


### PR DESCRIPTION
Three changes targeting Vercel Speed Insights mobile LCP (4.89s):

- Stream home page: extract data fetching into HomeContent async server component behind Suspense, so page shell renders at TTFB rather than waiting for auth + DB queries
- Replace correlated NOT EXISTS query in getOtherChurchEventsPaged with two-step notIn: pre-fetch followed church IDs (fast index lookup), then exclude via churchId notIn. Avoids per-row subquery scan.
- Add @@index([churchId]) to ChurchFollower to support the notIn lookup and any future joins on churchId