### PR TITLE
feat: add bookmark button to all event cards

### DIFF
--- a/app/(app)/(no-nav)/churches/[id]/_components/church-tabs.tsx
+++ b/app/(app)/(no-nav)/churches/[id]/_components/church-tabs.tsx
@@ -11,9 +11,10 @@ type ChurchWithDetails = NonNullable<Awaited<ReturnType<typeof getChurchById>>>;
 
 interface ChurchTabsProps {
   church: ChurchWithDetails;
+  isAuthenticated: boolean;
 }
 
-export function ChurchTabs({ church }: ChurchTabsProps) {
+export function ChurchTabs({ church, isAuthenticated }: ChurchTabsProps) {
   return (
     <Tabs defaultValue="about">
       <div className="bg-muted/20 sticky top-0 z-10 px-4 pt-2 backdrop-blur-sm">
@@ -35,7 +36,11 @@ export function ChurchTabs({ church }: ChurchTabsProps) {
         </TabsContent>
 
         <TabsContent value="events">
-          <EventsTab events={church.events} churchName={church.name} />
+          <EventsTab
+            events={church.events}
+            churchName={church.name}
+            isAuthenticated={isAuthenticated}
+          />
         </TabsContent>
 
         <TabsContent value="series">

--- a/app/(app)/(no-nav)/churches/[id]/_components/events-tab.tsx
+++ b/app/(app)/(no-nav)/churches/[id]/_components/events-tab.tsx
@@ -1,6 +1,7 @@
 import { CalendarDays } from "lucide-react";
 import { EventCard } from "@/domains/events/components/event-card";
 import { EmptyState } from "@/components/empty-state";
+import { SaveEventButton } from "@/domains/events/components/save-event-button";
 import type { getChurchById } from "@/domains/churches/actions/data";
 
 type ChurchWithDetails = NonNullable<Awaited<ReturnType<typeof getChurchById>>>;
@@ -8,9 +9,14 @@ type ChurchWithDetails = NonNullable<Awaited<ReturnType<typeof getChurchById>>>;
 interface EventsTabProps {
   events: ChurchWithDetails["events"];
   churchName: string;
+  isAuthenticated: boolean;
 }
 
-export function EventsTab({ events, churchName }: EventsTabProps) {
+export function EventsTab({
+  events,
+  churchName,
+  isAuthenticated,
+}: EventsTabProps) {
   return (
     <div>
       <h2 className="mb-3 text-lg font-bold">Upcoming Events</h2>
@@ -27,6 +33,13 @@ export function EventsTab({ events, churchName }: EventsTabProps) {
             <EventCard
               key={event.id}
               event={{ ...event, badge: event.tag, churchName }}
+              saveButton={
+                <SaveEventButton
+                  eventId={event.id}
+                  initialSaved={false}
+                  isAuthenticated={isAuthenticated}
+                />
+              }
             />
           ))}
         </div>

--- a/app/(app)/(no-nav)/churches/[id]/page.tsx
+++ b/app/(app)/(no-nav)/churches/[id]/page.tsx
@@ -142,7 +142,7 @@ export default async function ChurchDetailPage({ params }: Props) {
       </div>
 
       {/* Tabbed content */}
-      <ChurchTabs church={church} />
+      <ChurchTabs church={church} isAuthenticated={!!session?.user} />
     </div>
   );
 }

--- a/app/(app)/(no-nav)/events/[id]/page.tsx
+++ b/app/(app)/(no-nav)/events/[id]/page.tsx
@@ -40,7 +40,7 @@ import { CancelEventButton } from "./_components/cancel-event-button";
 import { UncancelEventButton } from "./_components/uncancel-event-button";
 import { EventActionBar } from "./_components/event-action-bar";
 import { CampAgenda } from "./_components/camp-agenda";
-import { SaveEventButton } from "./_components/save-event-button";
+import { SaveEventButton } from "@/domains/events/components/save-event-button";
 import {
   getMyRequestForResource,
   getPendingRequestsForResource,

--- a/app/(app)/(no-nav)/series/[id]/page.tsx
+++ b/app/(app)/(no-nav)/series/[id]/page.tsx
@@ -171,13 +171,11 @@ export default async function SeriesDetailPage({ params }: Props) {
                   churchName: series.church?.name ?? "",
                 }}
                 saveButton={
-                  session?.user?.id ? (
-                    <SaveEventButton
-                      eventId={event.id}
-                      initialSaved={false}
-                      isAuthenticated={true}
-                    />
-                  ) : undefined
+                  <SaveEventButton
+                    eventId={event.id}
+                    initialSaved={false}
+                    isAuthenticated={!!session?.user?.id}
+                  />
                 }
               />
             ))

--- a/app/(app)/(no-nav)/series/[id]/page.tsx
+++ b/app/(app)/(no-nav)/series/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Capabilities } from "@/domains/roles/lib/capabilities";
 import { InfoField } from "@/components/ui/info-field";
 import { HeroBanner } from "@/components/ui/hero-banner";
 import { EventCard } from "@/domains/events/components/event-card";
+import { SaveEventButton } from "@/domains/events/components/save-event-button";
 import { Button } from "@/components/ui/button";
 import { DeleteSeriesButton } from "./_components/delete-series-button";
 import { FollowSeriesButton } from "./_components/follow-series-button";
@@ -169,6 +170,15 @@ export default async function SeriesDetailPage({ params }: Props) {
                   badge: event.tag,
                   churchName: series.church?.name ?? "",
                 }}
+                saveButton={
+                  session?.user?.id ? (
+                    <SaveEventButton
+                      eventId={event.id}
+                      initialSaved={false}
+                      isAuthenticated={true}
+                    />
+                  ) : undefined
+                }
               />
             ))
           )}

--- a/app/(app)/(with-nav)/my-events/_components/my-events-tab.tsx
+++ b/app/(app)/(with-nav)/my-events/_components/my-events-tab.tsx
@@ -26,6 +26,7 @@ export function MyEventsTab({
         loadMore={loadMoreMyUpcomingEventsAction}
         title="Upcoming"
         emptyMessage="No upcoming events"
+        isAuthenticated={true}
       />
       <InfiniteEventList
         initialItems={pastItems}
@@ -33,6 +34,7 @@ export function MyEventsTab({
         loadMore={loadMoreMyPastEventsAction}
         title="Past"
         emptyMessage="No past events"
+        isAuthenticated={true}
       />
     </div>
   );

--- a/app/(app)/(with-nav)/organiser/_components/community-tab.tsx
+++ b/app/(app)/(with-nav)/organiser/_components/community-tab.tsx
@@ -23,6 +23,7 @@ export function CommunityTab({ items, cursor, series }: CommunityTabProps) {
         loadMore={loadMoreCommunityEventsAction}
         title="Events"
         emptyMessage="No events from others"
+        isAuthenticated={true}
       />
 
       <section className="flex flex-col gap-3">

--- a/app/(app)/(with-nav)/organiser/_components/my-content-tab.tsx
+++ b/app/(app)/(with-nav)/organiser/_components/my-content-tab.tsx
@@ -23,6 +23,7 @@ export function MyContentTab({ items, cursor, series }: MyContentTabProps) {
         loadMore={loadMoreMyCreatedEventsAction}
         title="My Events"
         emptyMessage="No upcoming events"
+        isAuthenticated={true}
       />
 
       <section className="flex flex-col gap-3">

--- a/app/(app)/(with-nav)/page.tsx
+++ b/app/(app)/(with-nav)/page.tsx
@@ -14,6 +14,7 @@ import {
   loadMoreMySavedEventsAction,
 } from "@/domains/events/actions/pagination";
 import { PageHeader } from "@/components/ui/page-header";
+import { SaveEventButton } from "@/domains/events/components/save-event-button";
 import { WHEN_LABELS, TYPE_LABELS, type WhenFilter } from "@/lib/types/search";
 import { searchParamsSchema } from "@/lib/validations/search";
 import { HomeEventTabs } from "@/domains/events/components/home-event-tabs";
@@ -35,7 +36,7 @@ export default async function Home({
   const query = q?.trim() ?? "";
   const hasFilters = !!(query || type !== "all" || when || category);
 
-  const userId = hasFilters ? null : ((await auth())?.user?.id ?? null);
+  const userId = (await auth())?.user?.id ?? null;
 
   const [searchResults, followedPage, otherPage, savedPage] = await Promise.all(
     [
@@ -112,6 +113,15 @@ export default async function Home({
                         badge: event.tag,
                         churchName: event.church?.name ?? "",
                       }}
+                      saveButton={
+                        userId ? (
+                          <SaveEventButton
+                            eventId={event.id}
+                            initialSaved={false}
+                            isAuthenticated={true}
+                          />
+                        ) : undefined
+                      }
                     />
                   ))}
                 </section>

--- a/domains/events/actions/data.ts
+++ b/domains/events/actions/data.ts
@@ -243,7 +243,7 @@ export async function getFollowedChurchEventsPaged(
   userId: string,
   cursor: string | null
 ): Promise<{ items: EventCardItem[]; nextCursor: string | null }> {
-  cacheTag("events-list", `user-follows-${userId}`);
+  cacheTag("events-list", `user-follows-${userId}`, `saved-events-${userId}`);
   cacheLife("minutes");
   const rows = await prisma.event.findMany({
     where: {
@@ -254,11 +254,18 @@ export async function getFollowedChurchEventsPaged(
     orderBy: { datetime: "asc" },
     take: PAGE_SIZE + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-    include: { church: { select: { name: true } } },
+    include: {
+      church: { select: { name: true } },
+      savedBy: { where: { userId }, select: { id: true } },
+    },
   });
   const hasMore = rows.length > PAGE_SIZE;
+  const page = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
   return {
-    items: hasMore ? rows.slice(0, PAGE_SIZE) : rows,
+    items: page.map(({ savedBy, ...row }) => ({
+      ...row,
+      isSaved: savedBy.length > 0,
+    })),
     nextCursor: hasMore ? rows[PAGE_SIZE - 1].id : null,
   };
 }
@@ -268,19 +275,37 @@ export async function getOtherChurchEventsPaged(
   cursor: string | null
 ): Promise<{ items: EventCardItem[]; nextCursor: string | null }> {
   if (userId !== null) {
-    cacheTag("events-list", `user-follows-${userId}`);
-  } else {
-    cacheTag("events-list");
+    cacheTag("events-list", `user-follows-${userId}`, `saved-events-${userId}`);
+    cacheLife("minutes");
+    const rows = await prisma.event.findMany({
+      where: {
+        church: { followers: { none: { userId } } },
+        datetime: { gte: new Date() },
+        isDraft: false,
+      },
+      orderBy: { datetime: "asc" },
+      take: PAGE_SIZE + 1,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      include: {
+        church: { select: { name: true } },
+        savedBy: { where: { userId }, select: { id: true } },
+      },
+    });
+    const hasMore = rows.length > PAGE_SIZE;
+    const page = hasMore ? rows.slice(0, PAGE_SIZE) : rows;
+    return {
+      items: page.map(({ savedBy, ...row }) => ({
+        ...row,
+        isSaved: savedBy.length > 0,
+      })),
+      nextCursor: hasMore ? rows[PAGE_SIZE - 1].id : null,
+    };
   }
+
+  cacheTag("events-list");
   cacheLife("minutes");
   const rows = await prisma.event.findMany({
-    where: {
-      ...(userId !== null
-        ? { church: { followers: { none: { userId } } } }
-        : {}),
-      datetime: { gte: new Date() },
-      isDraft: false,
-    },
+    where: { datetime: { gte: new Date() }, isDraft: false },
     orderBy: { datetime: "asc" },
     take: PAGE_SIZE + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
@@ -321,6 +346,7 @@ export async function getMySavedEventsPaged(
     isDraft: r.event.isDraft,
     photoUrl: r.event.photoUrl,
     church: r.event.church,
+    isSaved: true,
   }));
   return {
     items,

--- a/domains/events/components/__tests__/infinite-event-list.test.tsx
+++ b/domains/events/components/__tests__/infinite-event-list.test.tsx
@@ -9,6 +9,10 @@ jest.mock("@/domains/events/components/event-card", () => ({
   ),
 }));
 
+jest.mock("@/domains/events/components/save-event-button", () => ({
+  SaveEventButton: () => null,
+}));
+
 // Mock EmptyState
 jest.mock("@/components/empty-state", () => ({
   EmptyState: ({ label }: { label: string }) => (

--- a/domains/events/components/event-card.tsx
+++ b/domains/events/components/event-card.tsx
@@ -18,66 +18,76 @@ interface EventCardProps {
     photoUrl?: string | null;
   };
   priority?: boolean;
+  saveButton?: React.ReactNode;
 }
 
-export function EventCard({ event, priority = false }: EventCardProps) {
+export function EventCard({
+  event,
+  priority = false,
+  saveButton,
+}: EventCardProps) {
   return (
-    <Link href={`/events/${event.id}`}>
-      <Card className="shadow-card overflow-hidden rounded-2xl border-0 bg-white py-0">
-        <div className="flex flex-col">
-          {event.photoUrl && (
-            <div className="relative h-44 w-full">
-              <Image
-                src={event.photoUrl}
-                alt=""
-                fill
-                className="object-cover"
-                sizes="(max-width: 640px) 100vw, 50vw"
-                priority={priority}
-                placeholder="blur"
-                blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8e+/+fwAI9AN2hc9PNgAAAABJRU5ErkJggg=="
-              />
-            </div>
-          )}
-          <CardContent className="flex flex-col gap-1 p-4">
-            <div className="flex items-center justify-between">
-              <p className="text-primary text-xs font-semibold tracking-wide uppercase">
-                <EventDatetime datetime={event.datetime} />
+    <div className="relative">
+      <Link href={`/events/${event.id}`}>
+        <Card className="shadow-card overflow-hidden rounded-2xl border-0 bg-white py-0">
+          <div className="flex flex-col">
+            {event.photoUrl && (
+              <div className="relative h-44 w-full">
+                <Image
+                  src={event.photoUrl}
+                  alt=""
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 640px) 100vw, 50vw"
+                  priority={priority}
+                  placeholder="blur"
+                  blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8e+/+fwAI9AN2hc9PNgAAAABJRU5ErkJggg=="
+                />
+              </div>
+            )}
+            <CardContent className="flex flex-col gap-1 p-4">
+              <div className="flex items-center justify-between">
+                <p className="text-primary text-xs font-semibold tracking-wide uppercase">
+                  <EventDatetime datetime={event.datetime} />
+                </p>
+                {event.isDraft ? (
+                  <span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium whitespace-nowrap text-amber-700">
+                    Draft
+                  </span>
+                ) : event.cancelledAt ? (
+                  <span className="bg-destructive/10 text-destructive rounded-full px-2.5 py-1 text-xs font-medium whitespace-nowrap">
+                    Cancelled
+                  </span>
+                ) : (
+                  (() => {
+                    const colors = TAG_COLORS[event.tag as Category] ?? {
+                      bg: "bg-primary/10",
+                      text: "text-primary",
+                    };
+                    return (
+                      <span
+                        className={`rounded-full ${colors.bg} px-2.5 py-1 text-xs font-medium ${colors.text} whitespace-nowrap`}
+                      >
+                        {event.badge}
+                      </span>
+                    );
+                  })()
+                )}
+              </div>
+              <p className="text-lg leading-snug font-bold">{event.title}</p>
+              <p className="text-muted-foreground text-sm font-semibold">
+                {event.churchName}
               </p>
-              {event.isDraft ? (
-                <span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium whitespace-nowrap text-amber-700">
-                  Draft
-                </span>
-              ) : event.cancelledAt ? (
-                <span className="bg-destructive/10 text-destructive rounded-full px-2.5 py-1 text-xs font-medium whitespace-nowrap">
-                  Cancelled
-                </span>
-              ) : (
-                (() => {
-                  const colors = TAG_COLORS[event.tag as Category] ?? {
-                    bg: "bg-primary/10",
-                    text: "text-primary",
-                  };
-                  return (
-                    <span
-                      className={`rounded-full ${colors.bg} px-2.5 py-1 text-xs font-medium ${colors.text} whitespace-nowrap`}
-                    >
-                      {event.badge}
-                    </span>
-                  );
-                })()
-              )}
-            </div>
-            <p className="text-lg leading-snug font-bold">{event.title}</p>
-            <p className="text-muted-foreground text-sm font-semibold">
-              {event.churchName}
-            </p>
-            <p className="text-muted-foreground text-sm">
-              {event.host ?? "TBD"}
-            </p>
-          </CardContent>
-        </div>
-      </Card>
-    </Link>
+              <p className="text-muted-foreground text-sm">
+                {event.host ?? "TBD"}
+              </p>
+            </CardContent>
+          </div>
+        </Card>
+      </Link>
+      {saveButton && (
+        <div className="absolute right-3 bottom-3 z-10">{saveButton}</div>
+      )}
+    </div>
   );
 }

--- a/domains/events/components/home-event-tabs.tsx
+++ b/domains/events/components/home-event-tabs.tsx
@@ -37,6 +37,7 @@ export function HomeEventTabs({
         initialCursor={otherPage.nextCursor}
         loadMore={loadMoreOther}
         emptyMessage="No upcoming events"
+        isAuthenticated={false}
       />
     );
   }
@@ -84,6 +85,7 @@ export function HomeEventTabs({
           initialCursor={followedPage.nextCursor}
           loadMore={loadMoreFollowed}
           emptyMessage="No upcoming events from churches you follow"
+          isAuthenticated={isAuthenticated}
         />
       )}
       {active === "other" && (
@@ -92,6 +94,7 @@ export function HomeEventTabs({
           initialCursor={otherPage.nextCursor}
           loadMore={loadMoreOther}
           emptyMessage="No upcoming events"
+          isAuthenticated={isAuthenticated}
         />
       )}
       {active === "saved" && (
@@ -100,6 +103,7 @@ export function HomeEventTabs({
           initialCursor={savedPage.nextCursor}
           loadMore={loadMoreSaved}
           emptyMessage="No saved events"
+          isAuthenticated={isAuthenticated}
         />
       )}
     </div>

--- a/domains/events/components/infinite-event-list.tsx
+++ b/domains/events/components/infinite-event-list.tsx
@@ -5,6 +5,7 @@ import { CalendarDays } from "lucide-react";
 import { EventCard } from "./event-card";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { SaveEventButton } from "./save-event-button";
 import type { EventCardItem, LoadMoreFn } from "@/lib/types/pagination";
 
 interface InfiniteEventListProps {
@@ -13,6 +14,7 @@ interface InfiniteEventListProps {
   loadMore: LoadMoreFn;
   title?: string;
   emptyMessage?: string;
+  isAuthenticated?: boolean;
 }
 
 export function InfiniteEventList({
@@ -21,6 +23,7 @@ export function InfiniteEventList({
   loadMore,
   title,
   emptyMessage = "No events",
+  isAuthenticated = false,
 }: InfiniteEventListProps) {
   const [extraItems, setExtraItems] = useState<EventCardItem[]>([]);
   const [cursor, setCursor] = useState(initialCursor);
@@ -86,6 +89,13 @@ export function InfiniteEventList({
             badge: item.tag,
             churchName: item.church?.name ?? "",
           }}
+          saveButton={
+            <SaveEventButton
+              eventId={item.id}
+              initialSaved={item.isSaved ?? false}
+              isAuthenticated={isAuthenticated}
+            />
+          }
         />
       ))}
       {cursor && (

--- a/domains/events/components/save-event-button.tsx
+++ b/domains/events/components/save-event-button.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Heart } from "lucide-react";
+import { Bookmark } from "lucide-react";
 import {
   saveEventAction,
   unsaveEventAction,
@@ -55,8 +55,8 @@ export function SaveEventButton({
       className="p-1 disabled:opacity-50"
       type="button"
     >
-      <Heart
-        className={`size-5 transition-colors ${saved ? "fill-rose-500 text-rose-500" : "text-muted-foreground"}`}
+      <Bookmark
+        className={`size-5 transition-colors ${saved ? "fill-foreground text-foreground" : "text-muted-foreground"}`}
       />
     </button>
   );

--- a/domains/events/components/save-event-button.tsx
+++ b/domains/events/components/save-event-button.tsx
@@ -52,6 +52,7 @@ export function SaveEventButton({
       onClick={handleClick}
       disabled={isPending}
       aria-label={saved ? "Unsave event" : "Save event"}
+      aria-pressed={saved}
       className="p-1 disabled:opacity-50"
       type="button"
     >

--- a/lib/__tests__/data.test.ts
+++ b/lib/__tests__/data.test.ts
@@ -965,6 +965,38 @@ describe("getFollowedChurchEventsPaged", () => {
     expect(result.items).toHaveLength(0);
     expect(result.nextCursor).toBeNull();
   });
+
+  it("maps isSaved=true when event is in savedBy", async () => {
+    mockEventFindMany.mockResolvedValue([
+      { ...sampleEvent, savedBy: [{ id: "save-1" }] },
+    ]);
+
+    const result = await getFollowedChurchEventsPaged("user-1", null);
+
+    expect(result.items[0].isSaved).toBe(true);
+  });
+
+  it("maps isSaved=false when savedBy is empty", async () => {
+    mockEventFindMany.mockResolvedValue([{ ...sampleEvent, savedBy: [] }]);
+
+    const result = await getFollowedChurchEventsPaged("user-1", null);
+
+    expect(result.items[0].isSaved).toBe(false);
+  });
+
+  it("includes savedBy in the query", async () => {
+    mockEventFindMany.mockResolvedValue([sampleEvent]);
+
+    await getFollowedChurchEventsPaged("user-1", null);
+
+    expect(mockEventFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({
+          savedBy: { where: { userId: "user-1" }, select: { id: true } },
+        }),
+      })
+    );
+  });
 });
 
 describe("getOtherChurchEventsPaged", () => {
@@ -1014,6 +1046,32 @@ describe("getOtherChurchEventsPaged", () => {
 
     expect(result.items).toHaveLength(10);
     expect(result.nextCursor).toBe("evt-9");
+  });
+
+  it("maps isSaved=true for authenticated user when event is saved", async () => {
+    mockEventFindMany.mockResolvedValue([
+      { ...sampleEvent, savedBy: [{ id: "save-1" }] },
+    ]);
+
+    const result = await getOtherChurchEventsPaged("user-1", null);
+
+    expect(result.items[0].isSaved).toBe(true);
+  });
+
+  it("maps isSaved=false for authenticated user when event is not saved", async () => {
+    mockEventFindMany.mockResolvedValue([{ ...sampleEvent, savedBy: [] }]);
+
+    const result = await getOtherChurchEventsPaged("user-1", null);
+
+    expect(result.items[0].isSaved).toBe(false);
+  });
+
+  it("does not include isSaved for unauthenticated user", async () => {
+    mockEventFindMany.mockResolvedValue([sampleEvent]);
+
+    const result = await getOtherChurchEventsPaged(null, null);
+
+    expect(result.items[0].isSaved).toBeUndefined();
   });
 
   it("passes cursor when provided", async () => {

--- a/lib/__tests__/data.test.ts
+++ b/lib/__tests__/data.test.ts
@@ -86,6 +86,7 @@ const sampleEvent = {
   host: "Pastor John",
   tag: "Youth Meeting",
   createdAt: new Date(),
+  savedBy: [],
 };
 
 const sampleChurch = {

--- a/lib/types/pagination.ts
+++ b/lib/types/pagination.ts
@@ -8,6 +8,7 @@ export interface EventCardItem {
   isDraft?: boolean;
   photoUrl?: string | null;
   church: { name: string } | null;
+  isSaved?: boolean;
 }
 
 export type LoadMoreFn = (


### PR DESCRIPTION
- Replace heart with Bookmark icon on save-event-button
- Restructure EventCard with relative wrapper + absolute save slot (render prop) to avoid button-in-anchor HTML issue
- Move SaveEventButton from route-local _components to domains/events/components
- Enrich getFollowedChurchEventsPaged and getOtherChurchEventsPaged with savedBy join + isSaved field; add saved-events cache tag so save/unsave invalidates lists
- getMySavedEventsPaged hardcodes isSaved: true
- Thread isAuthenticated through InfiniteEventList, HomeEventTabs, ChurchTabs, EventsTab, MyEventsTab, MyContentTab, CommunityTab, series and church pages