### PR TITLE
feat: add push notification permission banner to inbox

### DIFF
--- a/app/(app)/(with-nav)/inbox/_components/__tests__/push-notification-banner.test.tsx
+++ b/app/(app)/(with-nav)/inbox/_components/__tests__/push-notification-banner.test.tsx
@@ -1,0 +1,178 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PushNotificationBanner } from "../push-notification-banner";
+
+const mockCheckPermissions = jest.fn();
+const mockRequestPermissions = jest.fn();
+const mockAppAddListener = jest.fn();
+
+jest.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: jest.fn().mockReturnValue(false),
+    getPlatform: jest.fn().mockReturnValue("android"),
+  },
+}));
+
+jest.mock("@capacitor/app", () => ({
+  App: {
+    addListener: (...args: unknown[]) => mockAppAddListener(...args),
+  },
+}));
+
+jest.mock("@capacitor/push-notifications", () => ({
+  PushNotifications: {
+    checkPermissions: (...args: unknown[]) => mockCheckPermissions(...args),
+    requestPermissions: (...args: unknown[]) => mockRequestPermissions(...args),
+  },
+}));
+
+const { Capacitor } = jest.requireMock("@capacitor/core") as {
+  Capacitor: { isNativePlatform: jest.Mock; getPlatform: jest.Mock };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  sessionStorage.clear();
+  Capacitor.isNativePlatform.mockReturnValue(false);
+  mockAppAddListener.mockResolvedValue({ remove: jest.fn() });
+});
+
+describe("PushNotificationBanner", () => {
+  it("renders nothing on web", () => {
+    Capacitor.isNativePlatform.mockReturnValue(false);
+
+    const { container } = render(<PushNotificationBanner />);
+
+    expect(container.firstChild).toBeNull();
+    expect(mockCheckPermissions).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when permissions already granted", async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "granted" });
+
+    const { container } = render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows banner when permission is "prompt"', async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "prompt" });
+
+    render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    expect(screen.getByText("Notifications are off")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Enable push notifications so you never miss an event update."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows banner when permission is "denied"', async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "denied" });
+
+    render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    expect(screen.getByText("Notifications are off")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Push notifications are disabled. If prompted, allow notifications to stay up to date."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("requests permissions when enable button clicked", async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "prompt" });
+    // Return denied to avoid triggering window.location.reload in test
+    mockRequestPermissions.mockResolvedValue({ receive: "denied" });
+
+    render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    await act(async () => {
+      await userEvent.click(screen.getByText("Enable notifications"));
+    });
+
+    expect(mockRequestPermissions).toHaveBeenCalled();
+  });
+
+  it("updates state to denied when permission request denied", async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "prompt" });
+    mockRequestPermissions.mockResolvedValue({ receive: "denied" });
+
+    render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    await act(async () => {
+      await userEvent.click(screen.getByText("Enable notifications"));
+    });
+
+    expect(
+      screen.getByText(
+        "Push notifications are disabled. If prompted, allow notifications to stay up to date."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("persists dismissal in sessionStorage", async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "prompt" });
+
+    render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    await act(async () => {
+      await userEvent.click(screen.getByLabelText("Dismiss"));
+    });
+
+    expect(sessionStorage.getItem("push-banner-dismissed")).toBe("1");
+    expect(screen.queryByText("Notifications are off")).not.toBeInTheDocument();
+  });
+
+  it("stays hidden when sessionStorage has dismiss flag", async () => {
+    sessionStorage.setItem("push-banner-dismissed", "1");
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "denied" });
+
+    const { container } = render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("listens for app resume via Capacitor App plugin", async () => {
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "denied" });
+
+    render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    expect(mockAppAddListener).toHaveBeenCalledWith(
+      "resume",
+      expect.any(Function)
+    );
+  });
+
+  it("cleans up resume listener on unmount", async () => {
+    const removeMock = jest.fn();
+    mockAppAddListener.mockResolvedValue({ remove: removeMock });
+    Capacitor.isNativePlatform.mockReturnValue(true);
+    mockCheckPermissions.mockResolvedValue({ receive: "denied" });
+
+    const { unmount } = render(<PushNotificationBanner />);
+    await act(() => Promise.resolve());
+
+    unmount();
+    await act(() => Promise.resolve());
+
+    expect(removeMock).toHaveBeenCalled();
+  });
+});

--- a/app/(app)/(with-nav)/inbox/_components/push-notification-banner.tsx
+++ b/app/(app)/(with-nav)/inbox/_components/push-notification-banner.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Capacitor } from "@capacitor/core";
+import { Capacitor, type PluginListenerHandle } from "@capacitor/core";
+import { App } from "@capacitor/app";
 import { PushNotifications } from "@capacitor/push-notifications";
 import { BellOff, X } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -9,12 +10,19 @@ import { Button } from "@/components/ui/button";
 
 type BannerState = "hidden" | "prompt" | "denied";
 
+const DISMISS_KEY = "push-banner-dismissed";
+
 export function PushNotificationBanner() {
   const [state, setState] = useState<BannerState>("hidden");
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return sessionStorage.getItem(DISMISS_KEY) === "1";
+  });
 
   useEffect(() => {
     if (!Capacitor.isNativePlatform()) return;
+
+    let handle: PluginListenerHandle | undefined;
 
     async function check() {
       const status = await PushNotifications.checkPermissions();
@@ -27,31 +35,30 @@ export function PushNotificationBanner() {
 
     check();
 
-    // Re-check when app resumes (user may have toggled in device settings)
-    const onResume = () => check();
-    document.addEventListener("resume", onResume);
-    return () => document.removeEventListener("resume", onResume);
+    App.addListener("resume", () => check()).then((h) => {
+      handle = h;
+    });
+
+    return () => {
+      handle?.remove();
+    };
   }, []);
 
   const handleEnable = useCallback(async () => {
-    if (state === "prompt") {
-      const result = await PushNotifications.requestPermissions();
-      if (result.receive === "granted") {
-        await PushNotifications.register();
-        setState("hidden");
-      } else if (result.receive === "denied") {
-        setState("denied");
-      }
-    } else if (state === "denied") {
-      // Once denied at OS level, re-request on Android 13+ may re-prompt.
-      // If it stays denied, the user must manually enable in device settings.
-      const result = await PushNotifications.requestPermissions();
-      if (result.receive === "granted") {
-        await PushNotifications.register();
-        setState("hidden");
-      }
+    const result = await PushNotifications.requestPermissions();
+    if (result.receive === "granted") {
+      // Reload so PushNotificationProvider re-inits with full listener
+      // setup and token registration — avoids duplicating that logic here.
+      window.location.reload();
+    } else if (result.receive === "denied") {
+      setState("denied");
     }
-  }, [state]);
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+    setDismissed(true);
+  }, []);
 
   if (state === "hidden" || dismissed) return null;
 
@@ -77,7 +84,7 @@ export function PushNotificationBanner() {
         </AlertDescription>
         <button
           className="absolute top-2 right-2 rounded-sm p-0.5 text-amber-400 hover:text-amber-600"
-          onClick={() => setDismissed(true)}
+          onClick={handleDismiss}
           aria-label="Dismiss"
         >
           <X className="size-4" />

--- a/app/(app)/(with-nav)/inbox/_components/push-notification-banner.tsx
+++ b/app/(app)/(with-nav)/inbox/_components/push-notification-banner.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Capacitor } from "@capacitor/core";
+import { PushNotifications } from "@capacitor/push-notifications";
+import { BellOff, X } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+type BannerState = "hidden" | "prompt" | "denied";
+
+export function PushNotificationBanner() {
+  const [state, setState] = useState<BannerState>("hidden");
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+
+    async function check() {
+      const status = await PushNotifications.checkPermissions();
+      if (status.receive === "prompt" || status.receive === "denied") {
+        setState(status.receive);
+      } else {
+        setState("hidden");
+      }
+    }
+
+    check();
+
+    // Re-check when app resumes (user may have toggled in device settings)
+    const onResume = () => check();
+    document.addEventListener("resume", onResume);
+    return () => document.removeEventListener("resume", onResume);
+  }, []);
+
+  const handleEnable = useCallback(async () => {
+    if (state === "prompt") {
+      const result = await PushNotifications.requestPermissions();
+      if (result.receive === "granted") {
+        await PushNotifications.register();
+        setState("hidden");
+      } else if (result.receive === "denied") {
+        setState("denied");
+      }
+    } else if (state === "denied") {
+      // Once denied at OS level, re-request on Android 13+ may re-prompt.
+      // If it stays denied, the user must manually enable in device settings.
+      const result = await PushNotifications.requestPermissions();
+      if (result.receive === "granted") {
+        await PushNotifications.register();
+        setState("hidden");
+      }
+    }
+  }, [state]);
+
+  if (state === "hidden" || dismissed) return null;
+
+  return (
+    <div className="px-4 pt-2">
+      <Alert className="relative border-amber-200 bg-amber-50">
+        <BellOff className="size-4 text-amber-600" />
+        <AlertTitle className="text-amber-900">
+          Notifications are off
+        </AlertTitle>
+        <AlertDescription className="text-amber-700">
+          {state === "prompt"
+            ? "Enable push notifications so you never miss an event update."
+            : "Push notifications are disabled. If prompted, allow notifications to stay up to date."}
+          <Button
+            size="sm"
+            variant="outline"
+            className="mt-2 border-amber-300 bg-amber-100 text-amber-900 hover:bg-amber-200"
+            onClick={handleEnable}
+          >
+            Enable notifications
+          </Button>
+        </AlertDescription>
+        <button
+          className="absolute top-2 right-2 rounded-sm p-0.5 text-amber-400 hover:text-amber-600"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss"
+        >
+          <X className="size-4" />
+        </button>
+      </Alert>
+    </div>
+  );
+}

--- a/app/(app)/(with-nav)/inbox/page.tsx
+++ b/app/(app)/(with-nav)/inbox/page.tsx
@@ -4,6 +4,7 @@ import { auth } from "@/auth";
 import { PageHeader } from "@/components/ui/page-header";
 import { getInboxNotifications } from "@/domains/notifications/inbox";
 import { InboxTabs } from "./_components/inbox-tabs";
+import { PushNotificationBanner } from "./_components/push-notification-banner";
 
 export const metadata: Metadata = {
   title: "Inbox — One Another",
@@ -23,6 +24,7 @@ export default async function InboxPage() {
   return (
     <div className="flex flex-col">
       <PageHeader title="Inbox" />
+      <PushNotificationBanner />
       <InboxTabs
         initialNotifications={notifications.slice(0, PAGE_SIZE)}
         hasMore={notifications.length > PAGE_SIZE}


### PR DESCRIPTION
Shows an amber alert at the top of the inbox when push notifications are not enabled, allowing users to re-trigger the permission request. Dismissible per session, re-checks on app resume.